### PR TITLE
注文確認時のバリデーション設定

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -41,39 +41,45 @@ class Public::OrdersController < ApplicationController
     @order.total_payment = @total_price + @order.charge
 
       if  params[:order][:select_address] == "0"
-
         @order.post_number = current_customer.post_number
         @order.address = current_customer.address
         @order.name = current_customer.last_name + current_customer.first_name
 
-      elsif　params[:order][:select_address] == "1"
-
-        @address = Address.find(params[:order][:address_id])
-        @order.post_number = @address.post_number
-        @order.address = @address.address
-        @order.name = @address.name
+      elsif params[:order][:select_address] == "1"
+        #登録した配送先を選択しなかった場合
+        unless current_customer.addresses.exists?
+          flash[:notice] = "登録済の住所が選択されていません"
+          render "new"
+        else
+          @address = Address.find(params[:order][:address_id])
+          @order.post_number = @address.post_number
+          @order.address = @address.address
+          @order.name = @address.name
+        end
 
       elsif params[:order][:select_address] == "2"
 
         if  params[:order][:post_number] == "" && params[:order][:address] == "" && params[:order][:name] == ""
 
           flash[:notice] = "新しいお届け先が全て入力されていません"
-          redirect_to new_order_path
+          render "new"
         elsif params[:order][:post_number] == ""
           flash[:notice] = "郵便番号が入力されていません"
-          redirect_to new_order_path
+          render "new"
         elsif params[:order][:address] == ""
           flash[:notice] = "住所が入力されていません"
-          redirect_to new_order_path
+          render "new"
         elsif params[:order][:name] == ""
           flash[:notice] = "宛名が入力されていません"
-          redirect_to new_order_path
+          render "new"
         else
           @order.post_number = params[:order][:post_number]
           @order.address = params[:order][:address]
           @order.name = params[:order][:name]
         end
       else
+         flash.now[:notice] = "住所を選択してください"
+         render "new"
       end
   end
 

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -59,7 +59,7 @@
         <td><%= order_detail.amount %></td>
         <td><%= ((order_detail.item.price * 1.1).round * (order_detail.amount)).to_s(:delimited) %></td>
         <td>
-          <%= form_with model: order_detail, url:  admin_order_detail_path(order_detail), method: :patch do |f| %>
+          <%= form_with model: order_detail, url: admin_order_detail_path(order_detail), method: :patch do |f| %>
           <%= f.select :production_status, OrderDetail.production_statuses_i18n.invert %>
           <%= f.submit "更新", class: "btn btn-success btn-sm px-4 ml-5" %>
           <% end %>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -31,7 +31,7 @@
       <div class="my-3"></div>
 
       <%= f.radio_button :select_address,1 %>登録済住所から選択<br>
-      <%= f.select :address_id, options_from_collection_for_select(Address.all, :id, :address_was), include_blank: "住所を選択してください" %>
+      <%= f.select :address_id, options_from_collection_for_select(Address.all, :id, :address_was) %>
 
        <div class="my-3"></div>
 


### PR DESCRIPTION
修正内容の解説です。

まず、public/order_controllerの変更点です。

 　elsif params[:order][:select_address] == "1"
        unless current_customer.addresses.exists?
          flash[:notice] = "登録済の住所が選択されていません"
          render "new"

👉『unless current_customer.addresses.exists?』の部分で登録済みの配送先情報がない場合の定義をしてます！
　遷移方法も念の為「render　new」に変更しております。

もう一つが解決するのに苦戦してしまったのですが、元々はセレクトボタン１の登録済住所から選択のボタンを選ぶ際に、「住所を選択してくだい」っていう任意の言葉を入れてたのですが、これがどうもIDを持っていないというエラーが出て厄介だったため、
public/order/new.html.erbのビューに記述していたこの部分を消して、登録済み住所がない場合は空白になるように変更したら、無事にバリデーション機能と、フラッシュメッセージが表示されました！
すでに新しい住所を登録している場合は一度、配送先一覧から、追加した住所を全て削除して試してみてください！（すでに追加している場合は空白ボタンが表示されないため）
もし不明点あればお伺いします！